### PR TITLE
update AddressUtxoResult object structure

### DIFF
--- a/typings/Address.d.ts
+++ b/typings/Address.d.ts
@@ -35,7 +35,6 @@ export declare interface AddressDetailsResult {
 }
 
 export declare interface AddressUtxoResult {
-    address: string;
     txid: string;
     vout: number;
     scriptPubKey: string;
@@ -43,6 +42,8 @@ export declare interface AddressUtxoResult {
     satoshis: number;
     height: number;
     confirmations: number;
+    legacyAddress: string;
+    cashAddress: string;
 }
 
 export declare interface AddressUnconfirmedResult {


### PR DESCRIPTION
I made `AddressUtxoResult` the correct structure which `https://rest.bitbox.earth/#/address/utxo` returns.

Refers to https://rest.bitbox.earth/#/address/utxo