### PR TITLE
Adds function to convert address to/from HASH160 hash

### DIFF
--- a/lib/Address.js
+++ b/lib/Address.js
@@ -49,7 +49,7 @@ var Address = function () {
       }
     }
 
-    // Converts address to RIPEMD-160 hash
+    // Converts any address format to hash160
 
   }, {
     key: 'toHash160',
@@ -59,16 +59,27 @@ var Address = function () {
       return bytes.hash.toString('hex');
     }
 
-    // Converts RIPEMD-160 hash to Legacy Address
+    // Converts hash160 to Legacy Address
 
   }, {
-    key: 'toLegacyAddressFromHash160',
-    value: function toLegacyAddressFromHash160(ripemd160) {
+    key: 'hash160ToLegacy',
+    value: function hash160ToLegacy(hash160) {
       var network = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _bitcoincashjsLib2.default.networks.bitcoin.pubKeyHash;
 
-      var buffer = Buffer(ripemd160, 'hex');
+      var buffer = Buffer(hash160, 'hex');
       var legacyAddress = _bitcoincashjsLib2.default.address.toBase58Check(buffer, network);
       return legacyAddress;
+    }
+
+    // Converts hash160 to Cash Address
+
+  }, {
+    key: 'hash160ToCash',
+    value: function hash160ToCash(hash160) {
+      var network = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _bitcoincashjsLib2.default.networks.bitcoin.pubKeyHash;
+
+      var legacyAddress = this.hash160ToLegacy(hash160, network);
+      return this.toCashAddress(legacyAddress);
     }
 
     // Test for address format.

--- a/lib/Address.js
+++ b/lib/Address.js
@@ -18,10 +18,6 @@ var _bitcoincashjsLib = require('bitcoincashjs-lib');
 
 var _bitcoincashjsLib2 = _interopRequireDefault(_bitcoincashjsLib);
 
-var _bs = require('bs58');
-
-var _bs2 = _interopRequireDefault(_bs);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -61,6 +57,18 @@ var Address = function () {
       var legacyAddress = _bchaddrjs2.default.toLegacyAddress(address);
       var bytes = _bitcoincashjsLib2.default.address.fromBase58Check(legacyAddress);
       return bytes.hash.toString('hex');
+    }
+
+    // Converts RIPEMD-160 hash to Legacy Address
+
+  }, {
+    key: 'toLegacyAddressFromHash160',
+    value: function toLegacyAddressFromHash160(ripemd160) {
+      var network = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _bitcoincashjsLib2.default.networks.bitcoin.pubKeyHash;
+
+      var buffer = Buffer(ripemd160, 'hex');
+      var legacyAddress = _bitcoincashjsLib2.default.address.toBase58Check(buffer, network);
+      return legacyAddress;
     }
 
     // Test for address format.

--- a/lib/Address.js
+++ b/lib/Address.js
@@ -18,6 +18,10 @@ var _bitcoincashjsLib = require('bitcoincashjs-lib');
 
 var _bitcoincashjsLib2 = _interopRequireDefault(_bitcoincashjsLib);
 
+var _bs = require('bs58');
+
+var _bs2 = _interopRequireDefault(_bs);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -47,6 +51,17 @@ var Address = function () {
       } else {
         return _bchaddrjs2.default.toCashAddress(address).split(':')[1];
       }
+    }
+
+    // Converts address to RIPEMD-160 hash
+
+  }, {
+    key: 'toHash160',
+    value: function toHash160(address) {
+      var legacyAddress = _bchaddrjs2.default.toLegacyAddress(address);
+      var bytes = _bs2.default.decode(legacyAddress);
+      var strippedBytes = bytes.slice(1, 21);
+      return strippedBytes.toString('hex');
     }
 
     // Test for address format.

--- a/lib/Address.js
+++ b/lib/Address.js
@@ -59,9 +59,8 @@ var Address = function () {
     key: 'toHash160',
     value: function toHash160(address) {
       var legacyAddress = _bchaddrjs2.default.toLegacyAddress(address);
-      var bytes = _bs2.default.decode(legacyAddress);
-      var strippedBytes = bytes.slice(1, 21);
-      return strippedBytes.toString('hex');
+      var bytes = _bitcoincashjsLib2.default.address.fromBase58Check(legacyAddress);
+      return bytes.hash.toString('hex');
     }
 
     // Test for address format.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,129 @@
 {
   "name": "bitbox-cli",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+      "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.51"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+      "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+      "requires": {
+        "@babel/types": "7.0.0-beta.51",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+      "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.51",
+        "@babel/template": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+      "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+      "requires": {
+        "@babel/types": "7.0.0-beta.51"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+      "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+      "requires": {
+        "@babel/types": "7.0.0-beta.51"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+      "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+      "requires": {
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+      "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY="
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+      "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
+        "lodash": "4.17.10"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+      "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.51",
+        "@babel/generator": "7.0.0-beta.51",
+        "@babel/helper-function-name": "7.0.0-beta.51",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
+        "debug": "3.1.0",
+        "globals": "11.7.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+      "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
+    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -14,9 +134,9 @@
       }
     },
     "@types/node": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
-      "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.1.tgz",
+      "integrity": "sha512-f+qQR5lLCB8UPhtk8Xm8RQvbR4ycD7MOsdiuAEQCYpz44bBx2g7JL0+iYBcjl9J7d0KT1sX2g0VGNeHfw+GXpg==",
       "dev": true
     },
     "abbrev": {
@@ -190,7 +310,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "requires": {
-        "follow-redirects": "1.5.5",
+        "follow-redirects": "1.5.7",
         "is-buffer": "1.1.6"
       }
     },
@@ -983,7 +1103,7 @@
       "integrity": "sha512-W06sUpprptb65JHbu2yFdv8Tg7o2OWpD5n2pMUIhuLOXC5c64eMW7y9Pg0IHd/Qe31e1KwnHT9H1w6Pf9r4Fkg==",
       "requires": {
         "bs58check": "2.1.2",
-        "cashaddrjs": "0.2.8"
+        "cashaddrjs": "0.2.9"
       }
     },
     "bech32": {
@@ -1034,11 +1154,1809 @@
     "bip32-utils": {
       "version": "github:Bitcoin-com/bip32-utils#318df796443311f7e12217542f7f45d3b7791f10",
       "requires": {
-        "bitbox-cli": "1.5.8",
+        "bitbox-cli": "1.5.12",
         "keccak": "1.4.0",
-        "nyc": "11.9.0",
+        "nyc": "12.0.2",
         "standard": "11.0.1",
         "tape": "4.9.1"
+      },
+      "dependencies": {
+        "nyc": {
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
+          "integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+          "requires": {
+            "archy": "1.0.0",
+            "arrify": "1.0.1",
+            "caching-transform": "1.0.1",
+            "convert-source-map": "1.5.1",
+            "debug-log": "1.0.1",
+            "default-require-extensions": "1.0.0",
+            "find-cache-dir": "0.1.1",
+            "find-up": "2.1.0",
+            "foreground-child": "1.5.6",
+            "glob": "7.1.2",
+            "istanbul-lib-coverage": "1.2.0",
+            "istanbul-lib-hook": "1.1.0",
+            "istanbul-lib-instrument": "2.3.2",
+            "istanbul-lib-report": "1.1.3",
+            "istanbul-lib-source-maps": "1.2.5",
+            "istanbul-reports": "1.4.1",
+            "md5-hex": "1.3.0",
+            "merge-source-map": "1.1.0",
+            "micromatch": "3.1.10",
+            "mkdirp": "0.5.1",
+            "resolve-from": "2.0.0",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "spawn-wrap": "1.4.2",
+            "test-exclude": "4.2.1",
+            "yargs": "11.1.0",
+            "yargs-parser": "8.1.0"
+          },
+          "dependencies": {
+            "align-text": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+              }
+            },
+            "amdefine": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "append-transform": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "default-require-extensions": "1.0.0"
+              }
+            },
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "arr-flatten": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "arr-union": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "assign-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async": {
+              "version": "1.5.2",
+              "bundled": true
+            },
+            "atob": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "base": {
+              "version": "0.11.2",
+              "bundled": true,
+              "requires": {
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "1.0.0",
+                    "is-data-descriptor": "1.0.0",
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "builtin-modules": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "cache-base": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
+              }
+            },
+            "caching-transform": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "md5-hex": "1.3.0",
+                "mkdirp": "0.5.1",
+                "write-file-atomic": "1.3.4"
+              }
+            },
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "center-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+              }
+            },
+            "class-utils": {
+              "version": "0.3.6",
+              "bundled": true,
+              "requires": {
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                }
+              }
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "collection-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
+              }
+            },
+            "commondir": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "convert-source-map": {
+              "version": "1.5.1",
+              "bundled": true
+            },
+            "copy-descriptor": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "4.1.3",
+                "which": "1.3.1"
+              }
+            },
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "default-require-extensions": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "strip-bom": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
+              },
+              "dependencies": {
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "1.0.0",
+                    "is-data-descriptor": "1.0.0",
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "error-ex": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "0.2.1"
+              }
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              },
+              "dependencies": {
+                "cross-spawn": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "lru-cache": "4.1.3",
+                    "shebang-command": "1.2.0",
+                    "which": "1.3.1"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "extend-shallow": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-plain-object": "2.0.4"
+                  }
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "1.0.0",
+                    "is-data-descriptor": "1.0.0",
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "find-cache-dir": {
+              "version": "0.1.1",
+              "bundled": true,
+              "requires": {
+                "commondir": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pkg-dir": "1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "2.0.0"
+              }
+            },
+            "for-in": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "foreground-child": {
+              "version": "1.5.6",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "4.0.2",
+                "signal-exit": "3.0.2"
+              }
+            },
+            "fragment-cache": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "map-cache": "0.2.2"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "get-caller-file": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "get-value": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "handlebars": {
+              "version": "4.0.11",
+              "bundled": true,
+              "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "requires": {
+                    "amdefine": "1.0.1"
+                  }
+                }
+              }
+            },
+            "has-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
+              }
+            },
+            "has-values": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "hosted-git-info": {
+              "version": "2.6.0",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "invert-kv": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-buffer": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "is-extendable": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-odd": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-number": "4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "4.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "isobject": "3.0.1"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-windows": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "istanbul-lib-coverage": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "istanbul-lib-hook": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "append-transform": "0.4.0"
+              }
+            },
+            "istanbul-lib-report": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "istanbul-lib-coverage": "1.2.0",
+                "mkdirp": "0.5.1",
+                "path-parse": "1.0.5",
+                "supports-color": "3.2.3"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "3.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "1.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "1.2.5",
+              "bundled": true,
+              "requires": {
+                "debug": "3.1.0",
+                "istanbul-lib-coverage": "1.2.0",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "source-map": "0.5.7"
+              }
+            },
+            "istanbul-reports": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "handlebars": "4.0.11"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            },
+            "lazy-cache": {
+              "version": "1.0.4",
+              "bundled": true,
+              "optional": true
+            },
+            "lcid": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "invert-kv": "1.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+              },
+              "dependencies": {
+                "path-exists": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "longest": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "lru-cache": {
+              "version": "4.1.3",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+              }
+            },
+            "map-cache": {
+              "version": "0.2.2",
+              "bundled": true
+            },
+            "map-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "object-visit": "1.0.1"
+              }
+            },
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "md5-o-matic": "0.1.1"
+              }
+            },
+            "md5-o-matic": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "mem": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "1.2.0"
+              }
+            },
+            "merge-source-map": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "source-map": "0.6.1"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.6.1",
+                  "bundled": true
+                }
+              }
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mixin-deep": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-plain-object": "2.0.4"
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "nanomatch": {
+              "version": "1.2.9",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.6.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.3"
+              }
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "path-key": "2.0.1"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-copy": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                }
+              }
+            },
+            "object-visit": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "isobject": "3.0.1"
+              }
+            },
+            "object.pick": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isobject": "3.0.1"
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+              }
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "1.2.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "1.3.1"
+              }
+            },
+            "pascalcase": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "1.1.2"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                }
+              }
+            },
+            "posix-character-classes": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                }
+              }
+            },
+            "regex-not": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
+              }
+            },
+            "repeat-element": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "repeat-string": {
+              "version": "1.6.1",
+              "bundled": true
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "resolve-url": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "ret": {
+              "version": "0.1.15",
+              "bundled": true
+            },
+            "right-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "safe-regex": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "ret": "0.1.15"
+              }
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "set-value": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slide": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "snapdragon": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "snapdragon-node": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "1.0.0",
+                    "is-data-descriptor": "1.0.0",
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "snapdragon-util": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "source-map-resolve": {
+              "version": "0.5.2",
+              "bundled": true,
+              "requires": {
+                "atob": "2.1.1",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
+              }
+            },
+            "source-map-url": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "spawn-wrap": {
+              "version": "1.4.2",
+              "bundled": true,
+              "requires": {
+                "foreground-child": "1.5.6",
+                "mkdirp": "0.5.1",
+                "os-homedir": "1.0.2",
+                "rimraf": "2.6.2",
+                "signal-exit": "3.0.2",
+                "which": "1.3.1"
+              }
+            },
+            "spdx-correct": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "split-string": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "3.0.2"
+              }
+            },
+            "static-extend": {
+              "version": "0.1.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                }
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "test-exclude": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "arrify": "1.0.1",
+                "micromatch": "3.1.10",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
+              }
+            },
+            "to-object-path": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "to-regex": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
+              }
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  }
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "union-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "set-value": {
+                  "version": "0.4.3",
+                  "bundled": true,
+                  "requires": {
+                    "extend-shallow": "2.0.1",
+                    "is-extendable": "0.1.1",
+                    "is-plain-object": "2.0.4",
+                    "to-object-path": "0.3.0"
+                  }
+                }
+              }
+            },
+            "unset-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
+              },
+              "dependencies": {
+                "has-value": {
+                  "version": "0.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "get-value": "2.0.6",
+                    "has-values": "0.1.4",
+                    "isobject": "2.1.0"
+                  },
+                  "dependencies": {
+                    "isobject": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "isarray": "1.0.0"
+                      }
+                    }
+                  }
+                },
+                "has-values": {
+                  "version": "0.1.4",
+                  "bundled": true
+                }
+              }
+            },
+            "urix": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "use": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "isexe": "2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "bundled": true
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "11.1.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "4.1.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1",
+                    "strip-ansi": "4.0.0",
+                    "wrap-ansi": "2.1.0"
+                  }
+                },
+                "yargs-parser": {
+                  "version": "9.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "4.1.0"
+                  }
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "8.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        }
       }
     },
     "bip38": {
@@ -1081,9 +2999,9 @@
       "integrity": "sha512-O1htyufFTYy3EO0JkHg2CLykdXEtV2ssqw47Gq9A0WByp662xpJnMEB9m43LZjsSDjIAOozWRExlFQk2hlV1XQ=="
     },
     "bitbox-cli": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/bitbox-cli/-/bitbox-cli-1.5.8.tgz",
-      "integrity": "sha512-60dUEoup/9lslfW2QDVHTThBw8tZsPrmBTkAqR37RveZSlxEYDYrQw9oHBimkXzEaVakXdjLEBgrm4t/TAmYug==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/bitbox-cli/-/bitbox-cli-1.5.12.tgz",
+      "integrity": "sha512-SQk02foLnSEi8ZkJFTFLZXEEW/3ribb/YNaF2L/qZ1wtWOcB2uei4v/rmb31TJOseH6MvfZ5Ygl6HzcyCTpYHg==",
       "requires": {
         "assert": "1.4.1",
         "axios": "0.17.1",
@@ -1129,28 +3047,6 @@
         "socket.io-client": "2.1.1",
         "touch": "3.1.0",
         "wif": "2.0.6"
-      },
-      "dependencies": {
-        "bitcoincashjs-lib": {
-          "version": "github:Bitcoin-com/bitcoincashjs-lib#12fa5fe9b535816b54b9efedd6caf278d3e55b90",
-          "requires": {
-            "bech32": "1.1.3",
-            "bigi": "1.4.2",
-            "bip66": "1.1.5",
-            "bitcoin-ops": "github:Bitcoin-com/bitcoincash-ops#d62a0a12ce227a63222282b5f4e9a7a23a5a6b38",
-            "bs58check": "2.1.2",
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "ecurve": "1.0.6",
-            "merkle-lib": "2.0.10",
-            "pushdata-bitcoin": "1.0.1",
-            "randombytes": "2.0.6",
-            "safe-buffer": "5.1.2",
-            "typeforce": "1.12.0",
-            "varuint-bitcoin": "1.1.0",
-            "wif": "2.0.6"
-          }
-        }
       }
     },
     "bitcoin-ops": {
@@ -1214,7 +3110,7 @@
         "bs58check": "2.1.2",
         "buffer-equals": "1.0.4",
         "create-hash": "1.2.0",
-        "secp256k1": "3.5.0",
+        "secp256k1": "3.5.2",
         "varuint-bitcoin": "1.1.0"
       }
     },
@@ -1276,8 +3172,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000877",
-        "electron-to-chromium": "1.3.58"
+        "caniuse-lite": "1.0.30000878",
+        "electron-to-chromium": "1.3.61"
       }
     },
     "bs58": {
@@ -1359,14 +3255,14 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000877",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000877.tgz",
-      "integrity": "sha512-h04kV/lcuhItU1CZTJOxUEk/9R+1XeJqgc67E+XC8J9TjPM8kzVgOn27ZtRdDUo8O5F8U4QRCzDWJrVym3w3Cg=="
+      "version": "1.0.30000878",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
+      "integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA=="
     },
     "cashaddrjs": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.2.8.tgz",
-      "integrity": "sha512-oezXpKZRjavdRB1QjBamfHFDzYescGFn9dWMbijP4fgXrqMdBygOqaPNW4phf7zpRD4+oW7aaFfFklF72/szaA==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.2.9.tgz",
+      "integrity": "sha512-DhJF4iAH0/RM3UjHDHKRxzs09YGL9px+oTyizzydanhC7jTyM2aJ+aLKA96vZGTTWayvvr2iDF2l13lpqXiRFg==",
       "requires": {
         "big-integer": "1.6.34"
       }
@@ -1769,9 +3665,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.58",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.58.tgz",
-      "integrity": "sha512-AGJxlBEn2wOohxqWZkISVsOjZueKTQljfEODTDSEiMqSpH0S+xzV+/5oEM9AGaqhu7DzrpKOgU7ocQRjj0nJmg=="
+      "version": "1.3.61",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.61.tgz",
+      "integrity": "sha512-XjTdsm6x71Y48lF9EEvGciwXD70b20g0t+3YbrE+0fPFutqV08DSNrZXkoXAp3QuzX7TpL/OW+/VsNoR9GkuNg=="
     },
     "elliptic": {
       "version": "6.4.1",
@@ -2146,7 +4042,7 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
+        "iconv-lite": "0.4.24",
         "tmp": "0.0.33"
       }
     },
@@ -2246,9 +4142,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
-      "integrity": "sha512-GHjtHDlY/ehslqv0Gr5N0PUJppgg/q0rOBvX0na1s7y1A3LWxPqCYU76s3Z1bM4+UZB4QF0usaXLT5wFpof5PA==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
+      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
       "requires": {
         "debug": "3.1.0"
       }
@@ -2946,9 +4842,9 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": "2.1.2"
       }
@@ -3215,6 +5111,25 @@
       "optional": true,
       "requires": {
         "isarray": "1.0.0"
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA=="
+    },
+    "istanbul-lib-instrument": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
+      "integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
+      "requires": {
+        "@babel/generator": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/template": "7.0.0-beta.51",
+        "@babel/traverse": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
+        "istanbul-lib-coverage": "2.0.1",
+        "semver": "5.5.1"
       }
     },
     "js-tokens": {
@@ -3618,6 +5533,7 @@
       "version": "11.9.0",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
       "integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
+      "dev": true,
       "requires": {
         "archy": "1.0.0",
         "arrify": "1.0.1",
@@ -3651,6 +5567,7 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "3.2.2",
             "longest": "1.0.1",
@@ -3659,62 +5576,76 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "default-require-extensions": "1.0.0"
           }
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arr-diff": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "atob": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "esutils": "2.0.2",
@@ -3724,6 +5655,7 @@
         "babel-generator": {
           "version": "6.26.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-messages": "6.23.0",
             "babel-runtime": "6.26.0",
@@ -3738,6 +5670,7 @@
         "babel-messages": {
           "version": "6.23.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0"
           }
@@ -3745,6 +5678,7 @@
         "babel-runtime": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "core-js": "2.5.6",
             "regenerator-runtime": "0.11.1"
@@ -3753,6 +5687,7 @@
         "babel-template": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -3764,6 +5699,7 @@
         "babel-traverse": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "6.23.0",
@@ -3779,6 +5715,7 @@
         "babel-types": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
@@ -3788,15 +5725,18 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "base": {
           "version": "0.11.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cache-base": "1.0.1",
             "class-utils": "0.3.6",
@@ -3810,6 +5750,7 @@
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
               }
@@ -3817,6 +5758,7 @@
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -3824,6 +5766,7 @@
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -3831,6 +5774,7 @@
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "1.0.0",
                 "is-data-descriptor": "1.0.0",
@@ -3839,17 +5783,20 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -3858,6 +5805,7 @@
         "braces": {
           "version": "2.3.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-flatten": "1.1.0",
             "array-unique": "0.3.2",
@@ -3874,6 +5822,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -3882,11 +5831,13 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "collection-visit": "1.0.0",
             "component-emitter": "1.2.1",
@@ -3901,13 +5852,15 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "caching-transform": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "md5-hex": "1.3.0",
             "mkdirp": "0.5.1",
@@ -3917,11 +5870,13 @@
         "camelcase": {
           "version": "1.2.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "align-text": "0.1.4",
@@ -3931,6 +5886,7 @@
         "chalk": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "2.2.1",
             "escape-string-regexp": "1.0.5",
@@ -3942,6 +5898,7 @@
         "class-utils": {
           "version": "0.3.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-union": "3.1.0",
             "define-property": "0.2.5",
@@ -3952,19 +5909,22 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
               }
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "center-align": "0.1.3",
@@ -3975,17 +5935,20 @@
             "wordwrap": {
               "version": "0.0.2",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "map-visit": "1.0.0",
             "object-visit": "1.0.1"
@@ -3993,31 +5956,38 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "core-js": {
           "version": "2.5.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "4.1.3",
             "which": "1.3.0"
@@ -4026,25 +5996,30 @@
         "debug": {
           "version": "2.6.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "strip-bom": "2.0.0"
           }
@@ -4052,6 +6027,7 @@
         "define-property": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-descriptor": "1.0.2",
             "isobject": "3.0.1"
@@ -4060,6 +6036,7 @@
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -4067,6 +6044,7 @@
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -4074,6 +6052,7 @@
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "1.0.0",
                 "is-data-descriptor": "1.0.0",
@@ -4082,17 +6061,20 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "detect-indent": {
           "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "repeating": "2.0.1"
           }
@@ -4100,21 +6082,25 @@
         "error-ex": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-arrayish": "0.2.1"
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "execa": {
           "version": "0.7.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cross-spawn": "5.1.0",
             "get-stream": "3.0.0",
@@ -4128,6 +6114,7 @@
             "cross-spawn": {
               "version": "5.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "lru-cache": "4.1.3",
                 "shebang-command": "1.2.0",
@@ -4139,6 +6126,7 @@
         "expand-brackets": {
           "version": "2.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debug": "2.6.9",
             "define-property": "0.2.5",
@@ -4152,6 +6140,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
               }
@@ -4159,6 +6148,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -4168,6 +6158,7 @@
         "extend-shallow": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assign-symbols": "1.0.0",
             "is-extendable": "1.0.1"
@@ -4176,6 +6167,7 @@
             "is-extendable": {
               "version": "1.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-plain-object": "2.0.4"
               }
@@ -4185,6 +6177,7 @@
         "extglob": {
           "version": "2.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "array-unique": "0.3.2",
             "define-property": "1.0.0",
@@ -4199,6 +6192,7 @@
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
               }
@@ -4206,6 +6200,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -4213,6 +6208,7 @@
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -4220,6 +6216,7 @@
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -4227,6 +6224,7 @@
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "1.0.0",
                 "is-data-descriptor": "1.0.0",
@@ -4235,13 +6233,15 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "fill-range": {
           "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "2.0.1",
             "is-number": "3.0.0",
@@ -4252,6 +6252,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -4261,6 +6262,7 @@
         "find-cache-dir": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "commondir": "1.0.1",
             "mkdirp": "0.5.1",
@@ -4270,17 +6272,20 @@
         "find-up": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "locate-path": "2.0.0"
           }
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "foreground-child": {
           "version": "1.5.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
             "signal-exit": "3.0.2"
@@ -4289,29 +6294,35 @@
         "fragment-cache": {
           "version": "0.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "map-cache": "0.2.2"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -4323,15 +6334,18 @@
         },
         "globals": {
           "version": "9.18.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "async": "1.5.2",
             "optimist": "0.6.1",
@@ -4342,6 +6356,7 @@
             "source-map": {
               "version": "0.4.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "amdefine": "1.0.1"
               }
@@ -4351,17 +6366,20 @@
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "has-flag": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-value": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "get-value": "2.0.6",
             "has-values": "1.0.0",
@@ -4370,13 +6388,15 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "has-values": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "3.0.0",
             "kind-of": "4.0.0"
@@ -4385,6 +6405,7 @@
             "is-number": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
               },
@@ -4392,6 +6413,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
                   }
@@ -4401,6 +6423,7 @@
             "kind-of": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
               }
@@ -4409,15 +6432,18 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -4425,37 +6451,44 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "invariant": {
           "version": "2.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
           }
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           }
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "builtin-modules": "1.1.1"
           }
@@ -4463,6 +6496,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           }
@@ -4470,6 +6504,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
             "is-data-descriptor": "0.1.4",
@@ -4478,28 +6513,33 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-number": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           }
@@ -4507,60 +6547,72 @@
         "is-odd": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "4.0.0"
           },
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "append-transform": "0.4.0"
           }
@@ -4568,6 +6620,7 @@
         "istanbul-lib-instrument": {
           "version": "1.10.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-generator": "6.26.1",
             "babel-template": "6.26.0",
@@ -4581,6 +6634,7 @@
         "istanbul-lib-report": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "istanbul-lib-coverage": "1.2.0",
             "mkdirp": "0.5.1",
@@ -4591,6 +6645,7 @@
             "supports-color": {
               "version": "3.2.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "has-flag": "1.0.0"
               }
@@ -4600,6 +6655,7 @@
         "istanbul-lib-source-maps": {
           "version": "1.2.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debug": "3.1.0",
             "istanbul-lib-coverage": "1.2.0",
@@ -4611,6 +6667,7 @@
             "debug": {
               "version": "3.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4620,21 +6677,25 @@
         "istanbul-reports": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "handlebars": "4.0.11"
           }
         },
         "js-tokens": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -4642,11 +6703,13 @@
         "lazy-cache": {
           "version": "1.0.4",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "invert-kv": "1.0.0"
           }
@@ -4654,6 +6717,7 @@
         "load-json-file": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "2.2.0",
@@ -4665,6 +6729,7 @@
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-locate": "2.0.0",
             "path-exists": "3.0.0"
@@ -4672,21 +6737,25 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.10",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "js-tokens": "3.0.2"
           }
@@ -4694,6 +6763,7 @@
         "lru-cache": {
           "version": "4.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
@@ -4701,11 +6771,13 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "object-visit": "1.0.1"
           }
@@ -4713,17 +6785,20 @@
         "md5-hex": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
           }
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mem": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mimic-fn": "1.2.0"
           }
@@ -4731,19 +6806,22 @@
         "merge-source-map": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "micromatch": {
           "version": "3.1.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
             "array-unique": "0.3.2",
@@ -4762,28 +6840,33 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mixin-deep": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "for-in": "1.0.2",
             "is-extendable": "1.0.1"
@@ -4792,6 +6875,7 @@
             "is-extendable": {
               "version": "1.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-plain-object": "2.0.4"
               }
@@ -4801,17 +6885,20 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
             "array-unique": "0.3.2",
@@ -4829,21 +6916,25 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "2.6.0",
             "is-builtin-module": "1.0.0",
@@ -4854,21 +6945,25 @@
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "path-key": "2.0.1"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "copy-descriptor": "0.1.1",
             "define-property": "0.2.5",
@@ -4878,6 +6973,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
               }
@@ -4887,32 +6983,37 @@
         "object-visit": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "object.pick": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -4920,6 +7021,7 @@
         "optimist": {
           "version": "0.6.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8",
             "wordwrap": "0.0.3"
@@ -4927,11 +7029,13 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "execa": "0.7.0",
             "lcid": "1.0.0",
@@ -4940,11 +7044,13 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-try": "1.0.0"
           }
@@ -4952,47 +7058,56 @@
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-limit": "1.2.0"
           }
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "error-ex": "1.3.1"
           }
         },
         "pascalcase": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-type": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "pify": "2.3.0",
@@ -5001,15 +7116,18 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pinkie": "2.0.4"
           }
@@ -5017,6 +7135,7 @@
         "pkg-dir": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "find-up": "1.1.2"
           },
@@ -5024,6 +7143,7 @@
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
                 "pinkie-promise": "2.0.1"
@@ -5033,15 +7153,18 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "load-json-file": "1.1.0",
             "normalize-package-data": "2.4.0",
@@ -5051,6 +7174,7 @@
         "read-pkg-up": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "find-up": "1.1.2",
             "read-pkg": "1.1.0"
@@ -5059,6 +7183,7 @@
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
                 "pinkie-promise": "2.0.1"
@@ -5068,11 +7193,13 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "regex-not": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "3.0.2",
             "safe-regex": "1.1.0"
@@ -5080,42 +7207,51 @@
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "repeating": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-finite": "1.0.2"
           }
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "right-align": {
           "version": "0.1.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "align-text": "0.1.4"
@@ -5124,6 +7260,7 @@
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "7.1.2"
           }
@@ -5131,21 +7268,25 @@
         "safe-regex": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ret": "0.1.15"
           }
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "set-value": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "2.0.1",
             "is-extendable": "0.1.1",
@@ -5156,6 +7297,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -5165,25 +7307,30 @@
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "shebang-regex": "1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "base": "0.11.2",
             "debug": "2.6.9",
@@ -5198,6 +7345,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
               }
@@ -5205,6 +7353,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -5214,6 +7363,7 @@
         "snapdragon-node": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-property": "1.0.0",
             "isobject": "3.0.1",
@@ -5223,6 +7373,7 @@
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
               }
@@ -5230,6 +7381,7 @@
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -5237,6 +7389,7 @@
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -5244,6 +7397,7 @@
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "1.0.0",
                 "is-data-descriptor": "1.0.0",
@@ -5252,28 +7406,33 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           }
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "atob": "2.1.1",
             "decode-uri-component": "0.2.0",
@@ -5284,11 +7443,13 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
             "mkdirp": "0.5.1",
@@ -5301,6 +7462,7 @@
         "spdx-correct": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-expression-parse": "3.0.0",
             "spdx-license-ids": "3.0.0"
@@ -5308,11 +7470,13 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-exceptions": "2.1.0",
             "spdx-license-ids": "3.0.0"
@@ -5320,11 +7484,13 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "split-string": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "3.0.2"
           }
@@ -5332,6 +7498,7 @@
         "static-extend": {
           "version": "0.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-property": "0.2.5",
             "object-copy": "0.1.0"
@@ -5340,6 +7507,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
               }
@@ -5349,6 +7517,7 @@
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -5356,11 +7525,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -5370,6 +7541,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -5377,21 +7549,25 @@
         "strip-bom": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-utf8": "0.2.1"
           }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arrify": "1.0.1",
             "micromatch": "3.1.10",
@@ -5402,15 +7578,18 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "braces": {
               "version": "2.3.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "arr-flatten": "1.1.0",
                 "array-unique": "0.3.2",
@@ -5427,6 +7606,7 @@
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
                   }
@@ -5436,6 +7616,7 @@
             "expand-brackets": {
               "version": "2.1.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "debug": "2.6.9",
                 "define-property": "0.2.5",
@@ -5449,6 +7630,7 @@
                 "define-property": {
                   "version": "0.2.5",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-descriptor": "0.1.6"
                   }
@@ -5456,6 +7638,7 @@
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
                   }
@@ -5463,6 +7646,7 @@
                 "is-accessor-descriptor": {
                   "version": "0.1.6",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "kind-of": "3.2.2"
                   },
@@ -5470,6 +7654,7 @@
                     "kind-of": {
                       "version": "3.2.2",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "is-buffer": "1.1.6"
                       }
@@ -5479,6 +7664,7 @@
                 "is-data-descriptor": {
                   "version": "0.1.4",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "kind-of": "3.2.2"
                   },
@@ -5486,6 +7672,7 @@
                     "kind-of": {
                       "version": "3.2.2",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "is-buffer": "1.1.6"
                       }
@@ -5495,6 +7682,7 @@
                 "is-descriptor": {
                   "version": "0.1.6",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-accessor-descriptor": "0.1.6",
                     "is-data-descriptor": "0.1.4",
@@ -5503,13 +7691,15 @@
                 },
                 "kind-of": {
                   "version": "5.1.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "extglob": {
               "version": "2.0.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "array-unique": "0.3.2",
                 "define-property": "1.0.0",
@@ -5524,6 +7714,7 @@
                 "define-property": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-descriptor": "1.0.2"
                   }
@@ -5531,6 +7722,7 @@
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
                   }
@@ -5540,6 +7732,7 @@
             "fill-range": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "extend-shallow": "2.0.1",
                 "is-number": "3.0.0",
@@ -5550,6 +7743,7 @@
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
                   }
@@ -5559,6 +7753,7 @@
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -5566,6 +7761,7 @@
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
               }
@@ -5573,6 +7769,7 @@
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "1.0.0",
                 "is-data-descriptor": "1.0.0",
@@ -5582,6 +7779,7 @@
             "is-number": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
               },
@@ -5589,6 +7787,7 @@
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-buffer": "1.1.6"
                   }
@@ -5597,15 +7796,18 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "micromatch": {
               "version": "3.1.10",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "arr-diff": "4.0.0",
                 "array-unique": "0.3.2",
@@ -5626,11 +7828,13 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "to-object-path": {
           "version": "0.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           }
@@ -5638,6 +7842,7 @@
         "to-regex": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-property": "2.0.2",
             "extend-shallow": "3.0.2",
@@ -5648,6 +7853,7 @@
         "to-regex-range": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "3.0.0",
             "repeat-string": "1.6.1"
@@ -5656,6 +7862,7 @@
             "is-number": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
               }
@@ -5664,11 +7871,13 @@
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "source-map": "0.5.7",
@@ -5679,6 +7888,7 @@
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
+              "dev": true,
               "optional": true,
               "requires": {
                 "camelcase": "1.2.1",
@@ -5692,11 +7902,13 @@
         "uglify-to-browserify": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-union": "3.1.0",
             "get-value": "2.0.6",
@@ -5707,6 +7919,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -5714,6 +7927,7 @@
             "set-value": {
               "version": "0.4.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "extend-shallow": "2.0.1",
                 "is-extendable": "0.1.1",
@@ -5726,6 +7940,7 @@
         "unset-value": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "has-value": "0.3.1",
             "isobject": "3.0.1"
@@ -5734,6 +7949,7 @@
             "has-value": {
               "version": "0.3.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "get-value": "2.0.6",
                 "has-values": "0.1.4",
@@ -5743,6 +7959,7 @@
                 "isobject": {
                   "version": "2.1.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
                   }
@@ -5751,34 +7968,40 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "use": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "6.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-correct": "3.0.0",
             "spdx-expression-parse": "3.0.0"
@@ -5787,26 +8010,31 @@
         "which": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isexe": "2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "window-size": {
           "version": "0.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1"
@@ -5815,6 +8043,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
               }
@@ -5822,6 +8051,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -5832,11 +8062,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
@@ -5845,15 +8077,18 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yargs": {
           "version": "11.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cliui": "4.1.0",
             "decamelize": "1.2.0",
@@ -5871,15 +8106,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "cliui": {
               "version": "4.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "string-width": "2.1.1",
                 "strip-ansi": "4.0.0",
@@ -5889,6 +8127,7 @@
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -5896,6 +8135,7 @@
             "yargs-parser": {
               "version": "9.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "camelcase": "4.1.0"
               }
@@ -5905,13 +8145,15 @@
         "yargs-parser": {
           "version": "8.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "camelcase": "4.1.0"
           },
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         }
@@ -6606,9 +8848,9 @@
       "integrity": "sha1-Jiw28CMc+nZU4jY/o5TNLexm83g="
     },
     "secp256k1": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-      "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.2.tgz",
+      "integrity": "sha512-iin3kojdybY6NArd+UFsoTuapOF7bnJNf2UbcWXaY3z+E1sJDipl60vtzB5hbO/uquBu7z0fd4VC4Irp+xoFVQ==",
       "requires": {
         "bindings": "1.3.0",
         "bip66": "1.1.5",

--- a/src/Address.js
+++ b/src/Address.js
@@ -2,7 +2,6 @@ import axios from 'axios';
 import bchaddr from 'bchaddrjs';
 import Bitcoin from 'bitcoincashjs-lib';
 
-
 class Address {
   constructor(restURL) {
     this.restURL = restURL;

--- a/src/Address.js
+++ b/src/Address.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import bchaddr from 'bchaddrjs';
 import Bitcoin from 'bitcoincashjs-lib';
-import bs58 from 'bs58';
 
 
 class Address {
@@ -25,9 +24,8 @@ class Address {
   // Converts address to RIPEMD-160 hash
   toHash160(address) {
     let legacyAddress = bchaddr.toLegacyAddress(address);
-    let bytes = bs58.decode(legacyAddress);
-    let strippedBytes = bytes.slice(1,21);
-    return strippedBytes.toString('hex');
+    let bytes = Bitcoin.address.fromBase58Check(legacyAddress);
+    return bytes.hash.toString('hex');
   }
 
   // Test for address format.

--- a/src/Address.js
+++ b/src/Address.js
@@ -28,6 +28,13 @@ class Address {
     return bytes.hash.toString('hex');
   }
 
+  // Converts RIPEMD-160 hash to Legacy Address
+  toLegacyAddressFromHash160(ripemd160, network = Bitcoin.networks.bitcoin.pubKeyHash) {
+    let buffer = Buffer(ripemd160, 'hex');
+    let legacyAddress = Bitcoin.address.toBase58Check(buffer, network);
+    return legacyAddress;
+  }
+
   // Test for address format.
   isLegacyAddress(address) {
     return bchaddr.isLegacyAddress(address);

--- a/src/Address.js
+++ b/src/Address.js
@@ -21,18 +21,24 @@ class Address {
     }
   }
 
-  // Converts address to RIPEMD-160 hash
+  // Converts any address format to hash160
   toHash160(address) {
     let legacyAddress = bchaddr.toLegacyAddress(address);
     let bytes = Bitcoin.address.fromBase58Check(legacyAddress);
     return bytes.hash.toString('hex');
   }
 
-  // Converts RIPEMD-160 hash to Legacy Address
-  toLegacyAddressFromHash160(ripemd160, network = Bitcoin.networks.bitcoin.pubKeyHash) {
-    let buffer = Buffer(ripemd160, 'hex');
+  // Converts hash160 to Legacy Address
+  hash160ToLegacy(hash160, network = Bitcoin.networks.bitcoin.pubKeyHash) {
+    let buffer = Buffer(hash160, 'hex');
     let legacyAddress = Bitcoin.address.toBase58Check(buffer, network);
     return legacyAddress;
+  }
+
+  // Converts hash160 to Cash Address
+  hash160ToCash(hash160, network = Bitcoin.networks.bitcoin.pubKeyHash) {
+    let legacyAddress = this.hash160ToLegacy(hash160, network);
+    return this.toCashAddress(legacyAddress);
   }
 
   // Test for address format.

--- a/src/Address.js
+++ b/src/Address.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import bchaddr from 'bchaddrjs';
 import Bitcoin from 'bitcoincashjs-lib';
+import bs58 from 'bs58';
+
 
 class Address {
   constructor(restURL) {
@@ -18,6 +20,14 @@ class Address {
     } else {
       return bchaddr.toCashAddress(address).split(':')[1];
     }
+  }
+
+  // Converts address to RIPEMD-160 hash
+  toHash160(address) {
+    let legacyAddress = bchaddr.toLegacyAddress(address);
+    let bytes = bs58.decode(legacyAddress);
+    let strippedBytes = bytes.slice(1,21);
+    return strippedBytes.toString('hex');
   }
 
   // Test for address format.

--- a/test/Address.js
+++ b/test/Address.js
@@ -53,6 +53,12 @@ let CASHADDR_ADDRESSES_NO_PREFIX = CASHADDR_ADDRESSES.map((address) => {
   return parts[1];
 })
 
+let RIPEMD_160_HASHES = flatten([
+  fixtures.hash160MainnetP2PKH,
+  fixtures.hash160MainnetP2SH,
+  fixtures.hash160TestnetP2PKH
+]);
+
 let P2PKH_ADDRESSES = flatten([
   fixtures.legacyMainnetP2PKH,
   fixtures.legacyTestnetP2PKH,
@@ -129,6 +135,32 @@ describe('#addressConversion', () => {
         }, BITBOX.BitcoinCash.InvalidAddressError)
         assert.throws(() => {
           BITBOX.BitcoinCash.Addresst.toCashAddress('some invalid address')
+        }, BITBOX.BitcoinCash.InvalidAddressError)
+      })
+    });
+  });
+  describe('#toHash160', () => {
+    it('should convert legacy base58check address to hash160', () => {
+      assert.deepEqual(
+        LEGACY_ADDRESSES.map(BITBOX.Address.toHash160),
+        RIPEMD_160_HASHES
+      );
+    })
+
+    it('should convert cashaddr address to hash160', () => {
+      assert.deepEqual(
+        CASHADDR_ADDRESSES.map(BITBOX.Address.toHash160),
+        RIPEMD_160_HASHES
+      );
+    });
+
+    describe('errors', () => {
+      it('should fail when called with an invalid address', () => {
+        assert.throws(() => {
+          BITBOX.Address.toHash160()
+        }, BITBOX.BitcoinCash.InvalidAddressError)
+        assert.throws(() => {
+          BITBOX.Address.toHash160('some invalid address')
         }, BITBOX.BitcoinCash.InvalidAddressError)
       })
     });

--- a/test/Address.js
+++ b/test/Address.js
@@ -154,13 +154,45 @@ describe('#addressConversion', () => {
       );
     });
 
+    it('should build mainnet legacy base58check address from hash160', () => {
+      assert.deepEqual(
+        fixtures.hash160MainnetP2PKH.map(hash160 => BITBOX.Address.toLegacyAddressFromHash160(hash160)),
+        fixtures.legacyMainnetP2PKH
+      );
+    })
+
     describe('errors', () => {
       it('should fail when called with an invalid address', () => {
         assert.throws(() => {
           BITBOX.Address.toHash160()
         }, BITBOX.BitcoinCash.InvalidAddressError)
         assert.throws(() => {
+          BITBOX.Address.toLegacyAddressFromHash160()
+        }, BITBOX.BitcoinCash.InvalidAddressError)
+        assert.throws(() => {
           BITBOX.Address.toHash160('some invalid address')
+        }, BITBOX.BitcoinCash.InvalidAddressError)
+        assert.throws(() => {
+          BITBOX.Address.toLegacyAddressFromHash160('some invalid address')
+        }, BITBOX.BitcoinCash.InvalidAddressError)
+      })
+    });
+  });
+  describe('#toLegacyAddressFromHash160', () => {
+    it('should build mainnet legacy base58check address from hash160', () => {
+      assert.deepEqual(
+        fixtures.hash160MainnetP2PKH.map(hash160 => BITBOX.Address.toLegacyAddressFromHash160(hash160)),
+        fixtures.legacyMainnetP2PKH
+      );
+    })
+
+    describe('errors', () => {
+      it('should fail when called with an invalid address', () => {
+        assert.throws(() => {
+          BITBOX.Address.toLegacyAddressFromHash160()
+        }, BITBOX.BitcoinCash.InvalidAddressError)
+        assert.throws(() => {
+          BITBOX.Address.toLegacyAddressFromHash160('some invalid address')
         }, BITBOX.BitcoinCash.InvalidAddressError)
       })
     });

--- a/test/fixtures/Address.json
+++ b/test/fixtures/Address.json
@@ -71,6 +71,42 @@
     "bchtest:qpuxsqzgq3j0a58tnmwpgcrwwyrkenalevaeknklfg",
     "bchtest:qpgrlg0yqmdf4y8q980e57tx6v7vrvds2ug89n8w8q"
   ],
+  "hash160MainnetP2PKH": [
+    "573d93b475be4f1925f3b74ed951201b0147eac1",
+    "c6a872e524a03b7d400c425d7b974a35c78f4634",
+    "6c9456d8b14aeb409086a6ce817d4e7b74cc830c",
+    "428df38e23fc879a25819427995c3e6355b12d33",
+    "c9239ab0f3130c1f5596de6ef6c502727022caad",
+    "0cd440a628cd567915cf6963102392ac574d9a2d",
+    "f1c426f508cc2f9c02074445dfc45f31ab5400c2",
+    "22a22aeffc964232a6b59fe42c83c7d8a3381480",
+    "cce6fee93513534133fbd073fb34c62140f08782",
+    "a85a67d277620ab1cad3af3d0b02d19feaeb45fa"
+  ],
+  "hash160MainnetP2SH": [
+    "7dc85da64d1d93ef01ef62e0221c02f512e3942f",
+    "61c0d3b62301fa3aba01730134a9304c5f3fb809",
+    "c531daf34e8408743afeb55e905c51b99d7b99aa",
+    "6fbd9de114ffa0cedb176c28f6fd491bb65dc2c4",
+    "b411aa88d6f9f0bed9814d3dc1bd7f2a34d6aaec",
+    "8a0ce890399ff29c59425fd28fb9a8b33b16840d",
+    "81b93ac72a8b25817eee3d014b9d72e0ed9aebe5",
+    "656566b3157d3a3ee141c5a9ae974cb3d912b821",
+    "f9b7afcb0605f275ca6c5ebd8651964a051be276",
+    "8fd3c7df5aecc95a087ca5bdf3e0626c8080786a"
+  ],
+  "hash160TestnetP2PKH": [
+    "155187a3283b08b30519db50bc23bbba9f4b6657",
+    "452d79dbfc007e2d6d6b5bd0ca5d71390e0f38ed",
+    "9682e2bc8fdb7468fb020430ff3aee4aabba69cd",
+    "f3b561158da1b67fbb0df3c19d09436f7b53db22",
+    "6b24c67eabec94dbfd6f3e5d1a60a35634fd1535",
+    "fe034c5ce6aec620a0c8dfb7962475a53e79dbf1",
+    "eb59a465ca0cbf5fdf336cb496dd936054b9a636",
+    "6df4b55ae79ebed65e0d56e33156a74262d02f00",
+    "786800480464fed0eb9edc14606e71076ccfbfcb",
+    "503fa1e406da9a90e029df9a7966d33cc1b1b057"
+  ],
   "mainnetXPub": [
     {
       "xpub": "xpub6CVcpZVmPNjuniVYu1mLnLjDBfxWpx7LS25uxwRm5BLbXMCJmRaQgAxuqZDoYDeidJUh5QUatLJPWpeCkEK648hExyKFezqxJz4CMfEoYAc",


### PR DESCRIPTION
One of the use-cases of HASH160 is to store it in the OP_RETURN, instead of the legacy address base58check to save byte space.

Memo.cash uses this to store addresses in the OP_RETURN in the case of actions 0x6d06 and 0x6d07 for example.